### PR TITLE
ENABLED "on" vs "1"

### DIFF
--- a/matrix.php
+++ b/matrix.php
@@ -50,7 +50,7 @@ $ENABLED = $pluginSettings['ENABLED'];
 
 
 
-if($ENABLED != "1") {
+if($ENABLED != "on") {
 	logEntry("Plugin Status: DISABLED Please enable in Plugin Setup to use & Restart FPPD Daemon");
 	lockHelper::unlock();
 	exit(0);


### PR DESCRIPTION
The plugin writes "on" to indicate $ENABLED state. This causes a logic error as this file was expecting "1" to indicate $ENABLED.
