### PR TITLE
Update functions.inc.php

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -108,7 +108,7 @@ function createMatrixEventFile() {
 function outputMessages($queueMessages) {
 
 	global $DEBUG, $pluginDirectory,$MESSAGE_TIMEOUT, $fpp_matrixtools_Plugin, $fpp_matrixtools_Plugin_Script,$Matrix,$MATRIX_FONT,$MATRIX_FONT_SIZE,$MATRIX_PIXELS_PER_SECOND,$COLOR, $INCLUDE_TIME, $TIME_FORMAT, $HOUR_FORMAT,$SEPARATOR;
-
+                                               		// sjt 11/22/2021 - possible bug with pipe entered by user as "$SEPARATOR"
 	//print_r($queueMessages);
 	
 	if($DEBUG)


### PR DESCRIPTION
if the character "pipe" is defined by the user in the web interface as the separator, "$SEPARATOR" becomes an endless loop.
will likely need better parsing on the front end.  checking here for illegal characters could also be a good idea.